### PR TITLE
[Fixes #8] Initial Test cases Setup

### DIFF
--- a/controllers/ping_test.go
+++ b/controllers/ping_test.go
@@ -1,0 +1,21 @@
+package controllers
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+/*
+TestPing is a test function that sends a GET request to the "/api/v1/ping" route and
+verifies that the response has a 200 OK status code and a body of "pong".
+*/
+func TestPing(t *testing.T) {
+	recorder := makeRequest("GET", "/api/v1/ping", nil)
+
+	// Assert that the response status is 200 OK
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	// Assert that the response body is "pong"
+	assert.Equal(t, "pong", recorder.Body.String())
+}

--- a/controllers/upload.go
+++ b/controllers/upload.go
@@ -2,8 +2,8 @@ package controllers
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"path/filepath"
@@ -11,7 +11,7 @@ import (
 	"zestream-server/utils"
 )
 
-func GeneratePresignedURL(c *gin.Context) {
+func GeneratePresignedURL(c *gin.Context, s3Client s3iface.S3API) {
 
 	// Obtain the file name and extension from query params
 	fileName := c.Query("fileName")
@@ -25,14 +25,8 @@ func GeneratePresignedURL(c *gin.Context) {
 	// Generate a New Video ID
 	videoID := utils.VideoIDGen(extension)
 
-	// Create a new session
-	sess, _ := session.NewSession(&aws.Config{
-		Region: aws.String(constants.S3_REGION),
-	})
-	svc := s3.New(sess)
-
 	// Create a PutObjectRequest with the necessary parameters
-	req, _ := svc.PutObjectRequest(&s3.PutObjectInput{
+	req, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
 		Bucket: aws.String(constants.S3_BUCKET_NAME),
 		Key:    aws.String(videoID),
 	})

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/gin-gonic/gin v1.8.2
 	github.com/joho/godotenv v1.4.0
 	github.com/segmentio/kafka-go v0.4.38
+	github.com/stretchr/testify v1.8.1
 	github.com/u2takey/ffmpeg-go v0.4.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/u2takey/go-utils v0.3.1 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
@@ -33,4 +36,5 @@ require (
 	golang.org/x/text v0.5.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,7 +1,11 @@
 package routes
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gin-gonic/gin"
+	"zestream-server/constants"
 	"zestream-server/controllers"
 )
 
@@ -23,13 +27,27 @@ func Init() *gin.Engine {
 		}
 	})
 
+	// Create a new session
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(constants.S3_REGION),
+	})
+	if err != nil {
+		return nil
+	}
+
+	// Create a new S3 client
+	s3Client := s3.New(sess)
+
 	v1 := r.Group("/api/v1")
 
 	v1.GET("ping", controllers.Ping)
 
 	v1.POST("process-video", controllers.ProcessVideo)
 
-	v1.GET("generate-presigned-url", controllers.GeneratePresignedURL)
+	v1.GET("generate-presigned-url", func(c *gin.Context) {
+		controllers.GeneratePresignedURL(c, s3Client)
+	})
+
 	v1.POST("register_video_process", controllers.PublishMessage)
 
 	return r


### PR DESCRIPTION
- Added initial skeleton and helper function required for writing test cases.
- Added Test case for `/ping` endpoint
- Refactored the `GeneratePresignedURL` controller to use a single AWS s3 Session throughout, previously it used to create a new session for each API call



<img width="875" alt="Screenshot 2023-01-01 at 1 52 17 PM" src="https://user-images.githubusercontent.com/72073401/210164936-54fbb686-8020-4cdb-ac7f-575eaae6529d.png">
