### PR TITLE
fix: go version in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 ## Setup
 
-1. [Install/Update](https://go.dev/doc/install) Golang to v1.9
+1. [Install/Update](https://go.dev/doc/install) Golang to v1.19
 2. Fork the repo
 3. Clone the forked repo
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You want to implement the similar feature in your own product, without any hassl
 
 ## Dev Setup
 
-1. Install Golang v1.9 from [Go.dev](https://go.dev/doc/install)
+1. Install Golang v1.19 from [Go.dev](https://go.dev/doc/install)
 2. Fork this repo, and clone the forked repo
 3. `cd zestream-server`
 4. `go get .`


### PR DESCRIPTION
Starting with this :smile: 

I suppose go1.9 was written by mistake that's pretty old.