### PR TITLE
Replaced fatal logging

### DIFF
--- a/controllers/kafka.go
+++ b/controllers/kafka.go
@@ -34,6 +34,6 @@ func PublishMessage(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusExpectationFailed, gin.H{"error": message})
 	} else {
-		c.JSON(http.StatusCreated, gin.H{"status": "success"})
+		c.JSON(http.StatusCreated, gin.H{"status": message})
 	}
 }

--- a/controllers/kafka.go
+++ b/controllers/kafka.go
@@ -30,11 +30,10 @@ func PublishMessage(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	message := utils.PublishMessage(configs.EnvVar[configs.KAFKA_URI], string(jsonBytes), "video")
-	if message != "success" {
-		c.JSON(http.StatusCreated, gin.H{"status": "success"})
-		return
-	} else {
+	message, err := utils.PublishMessage(configs.EnvVar[configs.KAFKA_URI], string(jsonBytes), "video")
+	if err != nil {
 		c.JSON(http.StatusExpectationFailed, gin.H{"error": message})
+	} else {
+		c.JSON(http.StatusCreated, gin.H{"status": "success"})
 	}
 }

--- a/utils/kafka.go
+++ b/utils/kafka.go
@@ -8,14 +8,16 @@ import (
 	"github.com/segmentio/kafka-go"
 )
 
-func PublishMessage(kafkaURI, topic string, message string) string {
+func PublishMessage(kafkaURI, topic string, message string) (string, error) {
 
 	partition := 0
+	m := "success"
 
 	conn, err := kafka.DialLeader(context.Background(), "tcp", kafkaURI, topic, partition)
 	if err != nil {
-		log.Println("failed to dial leader:", err)
-		return err.Error()
+		m = "failed to dial leader"
+		log.Println(m, err)
+		return m, err
 	}
 
 	conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
@@ -23,14 +25,16 @@ func PublishMessage(kafkaURI, topic string, message string) string {
 		kafka.Message{Value: []byte(message)},
 	)
 	if err != nil {
-		log.Println("failed to write messages:", err)
-		return err.Error()
+		m = "failed to write messages"
+		log.Println(m, err)
+		return m, err
 	}
 
 	if err := conn.Close(); err != nil {
-		log.Println("failed to close writer:", err)
-		return err.Error()
+		m = "failed to close writer"
+		log.Println(m, err)
+		return m, err
 	}
 
-	return "success"
+	return m, nil
 }

--- a/utils/kafka.go
+++ b/utils/kafka.go
@@ -14,7 +14,8 @@ func PublishMessage(kafkaURI, topic string, message string) string {
 
 	conn, err := kafka.DialLeader(context.Background(), "tcp", kafkaURI, topic, partition)
 	if err != nil {
-		log.Fatal("failed to dial leader:", err)
+		log.Println("failed to dial leader:", err)
+		return err.Error()
 	}
 
 	conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
@@ -22,12 +23,12 @@ func PublishMessage(kafkaURI, topic string, message string) string {
 		kafka.Message{Value: []byte(message)},
 	)
 	if err != nil {
-		log.Fatal("failed to write messages:", err)
+		log.Println("failed to write messages:", err)
 		return err.Error()
 	}
 
 	if err := conn.Close(); err != nil {
-		log.Fatal("failed to close writer:", err)
+		log.Println("failed to close writer:", err)
 		return err.Error()
 	}
 


### PR DESCRIPTION
Replaced fatal logging with normal `log.Println` and returning the error to the controller for further handling. 
Haven't added in any log level as the base logger in go has no option for that.
Fixes #40 